### PR TITLE
Update step.js

### DIFF
--- a/backbone-pane-template/step.js
+++ b/backbone-pane-template/step.js
@@ -67,7 +67,7 @@ var Base = require('ribcage-view')
     var requiredProps = this.State.prototype._definition
 
     _.each(requiredProps, function eachRequiredProp(setting, prop){
-      if (setting.required && !options[prop])
+      if (setting.required && _.isUndefined(options[prop]))
         throw new Error(this.className + ' requires ' + prop)
     }, this)
 


### PR DESCRIPTION
fixes unintended thrown error when a prop is a boolean and the value is false
